### PR TITLE
implemented automigration at the startup of the backend container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,5 +21,7 @@ RUN pdm install --prod \
 # Expose the port Uvicorn will run on
 EXPOSE 8000
 
-# Command to run the app with hot reload disabled (for production)
-CMD ["pdm", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+COPY ./docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/backend/docker/entrypoint.sh
+++ b/backend/docker/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+set -e
+
+log() {
+  # Timestamp + log level + message
+  echo "$(date '+%Y-%m-%d %H:%M:%S') [entrypoint] $*"
+}
+
+log "Starting database migration…"
+if pdm run migrate; then
+  log "Database migration completed successfully."
+else
+  log "Database migration FAILED!"
+  exit 1
+fi
+
+log "Starting application server…"
+exec pdm run serve

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,6 +38,7 @@ migrate = "alembic upgrade head"
 migrationtest = "alembic/migration_test.sh"
 makemigration = "alembic revision --autogenerate -m"
 init_db = "python -m app.scripts.init_db"
+serve= "uvicorn app.main:app --host 0.0.0.0 --port 8000"
 
 [tool.pdm]
 package = [{include = "app"},   { include = "alembic" }]


### PR DESCRIPTION
- pyproject.toml now contains two scripts to run migration and the server
- entrypoint.sh is introduced to execute both on container startup
- Dockerfile now uses the new entrypoint.sh